### PR TITLE
feat(android): migrate automotive UI to Jetpack Compose (Material3 dark theme, bottom nav + FAB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ cd android
 ./gradlew :automotive:assembleDebug
 ```
 
+The automotive UI is now built with Jetpack Compose (Material 3) and a bottom navigation layout.
+
 ### Android Server Config (build-time)
 
 The Android client reads its server configuration from `BuildConfig` via `AppConfig`.

--- a/android/automotive/build.gradle.kts
+++ b/android/automotive/build.gradle.kts
@@ -32,6 +32,10 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -54,6 +58,14 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
     implementation("com.google.android.material:material:1.12.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.23")
+    implementation(platform("androidx.compose:compose-bom:2024.10.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.navigation:navigation-compose:2.8.3")
+    implementation("androidx.compose.material:material-icons-extended")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 
     // Networking
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/android/automotive/src/main/java/ccc/client/ui/CccApp.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/CccApp.kt
@@ -1,0 +1,131 @@
+package ccc.client.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+
+private enum class TopLevelDestination(
+    val route: String,
+    val label: String
+) {
+    Home("home", "Home"),
+    Browser("browser", "Browser"),
+    Files("files", "Files"),
+    Settings("settings", "Settings")
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CccApp(
+    homeState: HomeUiState,
+    diagnosticsProvider: () -> String,
+    onRetry: () -> Unit,
+    onOpenBrowserActivity: () -> Unit
+) {
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route ?: TopLevelDestination.Home.route
+
+    fun navigateTo(destination: TopLevelDestination) {
+        if (currentRoute == destination.route) return
+        navController.navigate(destination.route) {
+            popUpTo(navController.graph.findStartDestination().id) {
+                saveState = true
+            }
+            launchSingleTop = true
+            restoreState = true
+        }
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        floatingActionButtonPosition = FabPosition.Center,
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+                    if (currentRoute == TopLevelDestination.Browser.route) {
+                        onOpenBrowserActivity()
+                    } else {
+                        navigateTo(TopLevelDestination.Browser)
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            ) {
+                Icon(imageVector = Icons.Default.Public, contentDescription = "Open Browser")
+            }
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    selected = currentRoute == TopLevelDestination.Home.route,
+                    onClick = { navigateTo(TopLevelDestination.Home) },
+                    icon = { Icon(Icons.Default.Home, contentDescription = null) },
+                    label = { Text(TopLevelDestination.Home.label) }
+                )
+                NavigationBarItem(
+                    selected = currentRoute == TopLevelDestination.Browser.route,
+                    onClick = { navigateTo(TopLevelDestination.Browser) },
+                    icon = { Icon(Icons.Default.Public, contentDescription = null) },
+                    label = { Text(TopLevelDestination.Browser.label) }
+                )
+                NavigationBarItem(
+                    selected = currentRoute == TopLevelDestination.Files.route,
+                    onClick = { navigateTo(TopLevelDestination.Files) },
+                    icon = { Icon(Icons.Default.Folder, contentDescription = null) },
+                    label = { Text(TopLevelDestination.Files.label) }
+                )
+                NavigationBarItem(
+                    selected = currentRoute == TopLevelDestination.Settings.route,
+                    onClick = { navigateTo(TopLevelDestination.Settings) },
+                    icon = { Icon(Icons.Default.Settings, contentDescription = null) },
+                    label = { Text(TopLevelDestination.Settings.label) }
+                )
+            }
+        }
+    ) { paddingValues ->
+        NavHost(
+            navController = navController,
+            startDestination = TopLevelDestination.Home.route,
+            modifier = Modifier.padding(paddingValues)
+        ) {
+            composable(TopLevelDestination.Home.route) {
+                HomeScreen(
+                    state = homeState,
+                    diagnosticsProvider = diagnosticsProvider,
+                    onRetry = onRetry,
+                    onOpenBrowserTab = { navigateTo(TopLevelDestination.Browser) }
+                )
+            }
+            composable(TopLevelDestination.Browser.route) {
+                BrowserScreen(onOpenBrowserActivity = onOpenBrowserActivity)
+            }
+            composable(TopLevelDestination.Files.route) {
+                FilesScreen(onOpenBrowserActivity = onOpenBrowserActivity)
+            }
+            composable(TopLevelDestination.Settings.route) {
+                SettingsScreen()
+            }
+        }
+    }
+}

--- a/android/automotive/src/main/java/ccc/client/ui/HomeScreen.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/HomeScreen.kt
@@ -1,0 +1,170 @@
+package ccc.client.ui
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import ccc.client.ui.components.CccCard
+import ccc.client.ui.components.MonospaceBlock
+import ccc.client.ui.components.PrimaryButton
+import ccc.client.ui.components.SecondaryButton
+import ccc.client.ui.components.StatusPill
+
+@Composable
+fun HomeScreen(
+    state: HomeUiState,
+    diagnosticsProvider: () -> String,
+    onRetry: () -> Unit,
+    onOpenBrowserTab: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    var diagnosticsExpanded by remember { mutableStateOf(false) }
+    var diagnosticsText by remember { mutableStateOf("") }
+
+    val statusColor = when (state.statusLevel) {
+        StatusLevel.Ok -> MaterialTheme.colorScheme.primary
+        StatusLevel.Error -> MaterialTheme.colorScheme.error
+        StatusLevel.Neutral -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Text(text = "Server Status", style = MaterialTheme.typography.titleLarge)
+        }
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = state.statusText,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = statusColor
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    StatusPill(text = state.statusText, color = statusColor)
+                    if (state.isLoading) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Loading…",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+            }
+        }
+        item {
+            CccCard(title = "Connection") {
+                state.detailsText.lines().forEach { line ->
+                    Text(text = line, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+        item {
+            CccCard(title = "Server Details") {
+                if (state.messageLines.isEmpty()) {
+                    Text(
+                        text = "No details yet.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
+                } else {
+                    state.messageLines.forEach { line ->
+                        Text(text = line, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        }
+        item {
+            CccCard(title = "Actions") {
+                PrimaryButton(
+                    text = "Open Browser",
+                    onClick = onOpenBrowserTab,
+                    enabled = !state.isLoading
+                )
+                SecondaryButton(
+                    text = "Retry",
+                    onClick = onRetry,
+                    enabled = !state.isLoading
+                )
+                SecondaryButton(
+                    text = "Copy diagnostics",
+                    onClick = {
+                        val payload = diagnosticsProvider()
+                        diagnosticsText = payload
+                        clipboardManager.setText(AnnotatedString(payload))
+                        Toast.makeText(context, "Diagnostics copied to clipboard", Toast.LENGTH_SHORT)
+                            .show()
+                    },
+                    enabled = !state.isLoading
+                )
+            }
+        }
+        item {
+            CccCard(title = "Diagnostics") {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Diagnostics payload",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    TextButton(
+                        onClick = {
+                            diagnosticsExpanded = !diagnosticsExpanded
+                            if (diagnosticsExpanded) {
+                                diagnosticsText = diagnosticsProvider()
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = if (diagnosticsExpanded) {
+                                Icons.Default.ExpandLess
+                            } else {
+                                Icons.Default.ExpandMore
+                            },
+                            contentDescription = null
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(if (diagnosticsExpanded) "Hide" else "Show")
+                    }
+                }
+                if (diagnosticsExpanded) {
+                    MonospaceBlock(text = diagnosticsText)
+                }
+            }
+        }
+        item { Spacer(modifier = Modifier.height(12.dp)) }
+    }
+}

--- a/android/automotive/src/main/java/ccc/client/ui/HomeUiState.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/HomeUiState.kt
@@ -1,0 +1,19 @@
+package ccc.client.ui
+
+enum class StatusLevel {
+    Neutral,
+    Ok,
+    Error
+}
+
+data class HomeUiState(
+    val statusText: String = "Connecting…",
+    val statusLevel: StatusLevel = StatusLevel.Neutral,
+    val detailsText: String = "",
+    val messageLines: List<String> = emptyList(),
+    val isLoading: Boolean = false,
+    val lastAction: String? = null,
+    val lastActionSummary: String? = null,
+    val infoSummary: String = "<none>",
+    val versionSummary: String = "<none>"
+)

--- a/android/automotive/src/main/java/ccc/client/ui/PlaceholderScreens.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/PlaceholderScreens.kt
@@ -1,0 +1,73 @@
+package ccc.client.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ccc.client.ui.components.CccCard
+import ccc.client.ui.components.PrimaryButton
+
+@Composable
+fun BrowserScreen(onOpenBrowserActivity: () -> Unit) {
+    PlaceholderScreen(
+        title = "Browser",
+        description = "Open the full Browser activity to explore server commands and capabilities.",
+        buttonLabel = "Open Browser Activity",
+        onClick = onOpenBrowserActivity
+    )
+}
+
+@Composable
+fun FilesScreen(onOpenBrowserActivity: () -> Unit) {
+    PlaceholderScreen(
+        title = "Files",
+        description = "Files are managed in the Browser activity for now.",
+        buttonLabel = "Open Browser Activity",
+        onClick = onOpenBrowserActivity
+    )
+}
+
+@Composable
+fun SettingsScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        CccCard(title = "Settings") {
+            Text(
+                text = "Coming soon",
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaceholderScreen(
+    title: String,
+    description: String,
+    buttonLabel: String,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CccCard(title = title) {
+            Text(text = description, style = MaterialTheme.typography.bodyLarge)
+            PrimaryButton(text = buttonLabel, onClick = onClick)
+        }
+    }
+}

--- a/android/automotive/src/main/java/ccc/client/ui/components/CccComponents.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/components/CccComponents.kt
@@ -1,0 +1,113 @@
+package ccc.client.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CccCard(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surface,
+        shape = RoundedCornerShape(18.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            content()
+        }
+    }
+}
+
+@Composable
+fun PrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        enabled = enabled,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    ) {
+        Text(text = text, style = MaterialTheme.typography.labelLarge)
+    }
+}
+
+@Composable
+fun SecondaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        enabled = enabled,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = MaterialTheme.colorScheme.onSurface
+        )
+    ) {
+        Text(text = text, style = MaterialTheme.typography.labelLarge)
+    }
+}
+
+@Composable
+fun StatusPill(text: String, color: Color, modifier: Modifier = Modifier) {
+    Surface(
+        color = color.copy(alpha = 0.2f),
+        contentColor = color,
+        shape = RoundedCornerShape(999.dp),
+        modifier = modifier
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = text, style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}
+
+@Composable
+fun MonospaceBlock(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(12.dp),
+            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace)
+        )
+    }
+}

--- a/android/automotive/src/main/java/ccc/client/ui/theme/Color.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/theme/Color.kt
@@ -1,0 +1,16 @@
+package ccc.client.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val CccDarkPrimary = Color(0xFF2BD5C4)
+val CccDarkOnPrimary = Color(0xFF00201B)
+val CccDarkSecondary = Color(0xFF7CC8FF)
+val CccDarkOnSecondary = Color(0xFF001E2D)
+val CccDarkBackground = Color(0xFF0F1418)
+val CccDarkSurface = Color(0xFF151B21)
+val CccDarkSurfaceVariant = Color(0xFF1D242C)
+val CccDarkOutline = Color(0x1FFFFFFF)
+val CccDarkError = Color(0xFFFF6B6B)
+val CccDarkOnError = Color(0xFF2B0000)
+val CccDarkOnSurface = Color(0xFFE6EEF5)
+val CccDarkOnBackground = Color(0xFFE6EEF5)

--- a/android/automotive/src/main/java/ccc/client/ui/theme/Theme.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/theme/Theme.kt
@@ -1,0 +1,29 @@
+package ccc.client.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColorScheme = darkColorScheme(
+    primary = CccDarkPrimary,
+    onPrimary = CccDarkOnPrimary,
+    secondary = CccDarkSecondary,
+    onSecondary = CccDarkOnSecondary,
+    background = CccDarkBackground,
+    onBackground = CccDarkOnBackground,
+    surface = CccDarkSurface,
+    onSurface = CccDarkOnSurface,
+    surfaceVariant = CccDarkSurfaceVariant,
+    outline = CccDarkOutline,
+    error = CccDarkError,
+    onError = CccDarkOnError
+)
+
+@Composable
+fun CccTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = DarkColorScheme,
+        typography = CccTypography,
+        content = content
+    )
+}

--- a/android/automotive/src/main/java/ccc/client/ui/theme/Type.kt
+++ b/android/automotive/src/main/java/ccc/client/ui/theme/Type.kt
@@ -1,0 +1,46 @@
+package ccc.client.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val CccTypography = Typography(
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 22.sp,
+        lineHeight = 28.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 18.sp,
+        lineHeight = 24.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 28.sp,
+        lineHeight = 34.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 22.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    )
+)


### PR DESCRIPTION
### Motivation
- Replace the old programmatic View-based automotive dashboard with a modern Single-Activity Jetpack Compose shell using Material3 and a dark, card-based 3drop-inspired layout. 
- Provide a clear app-level navigation (bottom nav + centered FAB) and reusable UI tokens/components to speed further Compose work. 
- Preserve all existing networking, token handling and diagnostics semantics so server behavior and tests remain valid.

### Description
- Enable Compose for the `automotive` module by turning on `compose` in `android/automotive/build.gradle.kts`, setting `kotlinCompilerExtensionVersion`, and adding Compose + Navigation + Material3 dependencies. 
- Replace the old `MainActivity` with a Compose `ComponentActivity` that drives health/info/version checks into a `HomeUiState` and hosts the new Compose app shell (`CccApp`) and navigation. 
- Add a Material3 dark theme and design tokens under `ccc.client.ui.theme` plus reusable components in `ccc.client.ui.components` (`CccCard`, `PrimaryButton`, `SecondaryButton`, `StatusPill`, `MonospaceBlock`). 
- Implement `HomeScreen` Compose UI that mirrors previous diagnostics and health behavior (status, connection details, server details, retry/copy/open browser actions) and wire bottom nav tabs with placeholders for `Browser`, `Files`, and `Settings`; tapping Browser opens the existing `BrowserActivity` to preserve current functionality. 
- Keep all API/client behavior unchanged (`ApiClient`, DTOs, token handling, error formatting and diagnostics payload generation remain as before) and update `README.md` to note the Compose UI.

### Testing
- Ran the Android module build: `./gradlew :automotive:assembleDebug`, which failed due to missing Android SDK configuration (`SDK location not found; set ANDROID_HOME or sdk.dir in local.properties`). 
- No module JVM/MockWebServer unit tests were executed in this environment because the Android SDK/local properties are not available here; these should be verified in CI or a local environment with a configured SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698131f75ca08324880f678de5727c21)